### PR TITLE
WiP: feat: allow getScale() and getPrecision() to describe unset values

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/PGProperty.java
+++ b/pgjdbc/src/main/java/org/postgresql/PGProperty.java
@@ -645,6 +645,14 @@ public enum PGProperty {
     "Specifies the length to return for types of unknown length"),
 
   /**
+   * Specifies the scale to return for numerics of unknown scale.
+   */
+  UNKNOWN_SCALE(
+    "unknownScale",
+    Integer.toString(-127),
+    "Specifies the scale to return for numerics of unknown scale. Set to '0' for old behaviour"),
+
+  /**
    * Username to connect to the database as.
    */
   USER(

--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -516,6 +516,22 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
   }
 
   /**
+   * @param unknownScale unknown scale
+   * @see PGProperty#UNKNOWN_SCALE
+   */
+  public void setUnknownScale(int unknownScale) {
+    PGProperty.UNKNOWN_SCALE.set(properties, unknownScale);
+  }
+
+  /**
+   * @return unknown scale
+   * @see PGProperty#UNKNOWN_SCALE
+   */
+  public int getUnknownScale() {
+    return PGProperty.UNKNOWN_SCALE.getIntNoCheck(properties);
+  }
+
+  /**
    * @param seconds socket timeout
    * @see PGProperty#SOCKET_TIMEOUT
    */

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgConnection.java
@@ -281,9 +281,10 @@ public class PgConnection implements BaseConnection {
     rollbackQuery = createQuery("ROLLBACK", false, true).query;
 
     int unknownLength = PGProperty.UNKNOWN_LENGTH.getInt(info);
+    int unknownScale = PGProperty.UNKNOWN_SCALE.getInt(info);
 
     // Initialize object handling
-    typeCache = createTypeInfo(this, unknownLength);
+    typeCache = createTypeInfo(this, unknownLength, unknownScale);
     initObjectTypes(info);
 
     if (PGProperty.LOG_UNCLOSED_CONNECTIONS.getBoolean(info)) {
@@ -648,8 +649,8 @@ public class PgConnection implements BaseConnection {
     }
   }
 
-  protected TypeInfo createTypeInfo(BaseConnection conn, int unknownLength) {
-    return new TypeInfoCache(conn, unknownLength);
+  protected TypeInfo createTypeInfo(BaseConnection conn, int unknownLength, int unknownScale) {
+    return new TypeInfoCache(conn, unknownLength, unknownScale);
   }
 
   public TypeInfo getTypeInfo() {

--- a/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/TypeInfoCache.java
@@ -54,6 +54,7 @@ public class TypeInfoCache implements TypeInfo {
 
   private BaseConnection conn;
   private final int unknownLength;
+  private final int unknownScale;
   private PreparedStatement getOidStatementSimple;
   private PreparedStatement getOidStatementComplexNonArray;
   private PreparedStatement getOidStatementComplexArray;
@@ -116,9 +117,10 @@ public class TypeInfoCache implements TypeInfo {
     typeAliases.put("decimal", "numeric");
   }
 
-  public TypeInfoCache(BaseConnection conn, int unknownLength) {
+  public TypeInfoCache(BaseConnection conn, int unknownLength, int unknownScale) {
     this.conn = conn;
     this.unknownLength = unknownLength;
+    this.unknownScale = unknownScale;
     oidToPgName = new HashMap<Integer, String>((int) Math.round(types.length * 1.5));
     pgNameToOid = new HashMap<String, Integer>((int) Math.round(types.length * 1.5));
     pgNameToJavaClass = new HashMap<String, String>((int) Math.round(types.length * 1.5));
@@ -646,7 +648,7 @@ public class TypeInfoCache implements TypeInfo {
 
       case Oid.NUMERIC:
         if (typmod == -1) {
-          return 0;
+          return 131072; // https://www.postgresql.org/docs/current/datatype-numeric.html
         }
         return ((typmod - 4) & 0xFFFF0000) >> 16;
 
@@ -696,7 +698,7 @@ public class TypeInfoCache implements TypeInfo {
         return 17;
       case Oid.NUMERIC:
         if (typmod == -1) {
-          return 0;
+          return unknownScale;
         }
         return (typmod - 4) & 0xFFFF;
       case Oid.TIME:


### PR DESCRIPTION
A scale of null was previously reported as 0, the same as an actual 0.
This changes the value used to represent an unset scale to -127, as in the Oracle
JDBC Driver, and adds a config parameter that allows the user to
specify a different value in the connection string, to get the
old behaviour (or any other value needed).

The value returned by getPrecision() for an unset precision on a
Numeric column was also 0, which would mean a column can only store 0.
This change sets to the maximum possible value for precision
(according to the documentation and experimentation).

The reason for using a high, but possible, value for precision and
an impossible value for scale is that they have different meanings.
A high precision p means *up to* p digits, while a high scale s
means there *are* exactly s digits after the decimal point. This
difference has implications for recorded accuracy as well as
display formatting.

Signed-off-by: crwr45 <charlie.wheelerrobinson@gmail.com>
